### PR TITLE
Removed syntax highlight for error

### DIFF
--- a/_sass/syntax.scss
+++ b/_sass/syntax.scss
@@ -1,7 +1,7 @@
 .highlight {
 .hll { background-color: #ffffcc }
 .c { color: #999988; font-style: italic } /* Comment */
-.err { color: #a61717; background-color: #e3d2d2 } /* Error */
+/*.err { color: #a61717; background-color: #e3d2d2 }*/ /* Error */
 .k { color: #000000; font-weight: bold } /* Keyword */
 .o { color: #000000; font-weight: bold } /* Operator */
 .cm { color: #999988; font-style: italic } /* Comment.Multiline */


### PR DESCRIPTION
The error highlight is wron. Gets used where it should not be used. Easy fix is to remove it. Correct fix is to find out how the error is generated.